### PR TITLE
RFC : 3 new Regularizers

### DIFF
--- a/src/EmpiricalRisks.jl
+++ b/src/EmpiricalRisks.jl
@@ -71,6 +71,9 @@ export
     SqrL2Reg,
     L1Reg,
     ElasticReg,
+    NonNegReg,
+    SimplexReg,
+    L1BallReg,
 
     prox, prox!
 

--- a/test/regularizers.jl
+++ b/test/regularizers.jl
@@ -66,3 +66,100 @@ verify_reg(ElasticReg(c1, c2), g0, θ,
     shrink(1.0 / (1.0 + c2) * θ, c1 / (1.0 + c2)))
 
 @test_approx_eq prox(ElasticReg(c1, c2), θ, 1.5) prox(ElasticReg(1.5 * c1, 1.5 * c2), θ)
+
+
+# Projection regularizers: NonNegReg, SimplexReg, L1BallReg
+
+reg = NonNegReg()
+
+θ = [0.1, 0.9]
+@test value(reg, θ) == 0.
+@test_throws ErrorException value_and_addgrad!(reg, 0., similar(θ), 1., θ) 
+@test prox!(reg, θ, θ, 1.0) == [0.1, 0.9]
+
+θ = [0.2, -0.5]
+@test value(reg, θ) == Inf 
+@test prox!(reg, θ, θ, 1.0) == [0.2, 0.]
+
+θ = [0., -1., 4., -0.1]
+@test value(reg, θ) == Inf
+@test prox!(reg, θ, θ, 1.0) == [0., 0., 4., 0.]
+
+θ = [0. 1. ; -1. 0]
+@test value(reg, θ) == Inf  
+@test prox!(reg, θ, θ, 1.0) == [0. 1. ; 0. 0.]
+
+θ = [0. 0.5 ; 0.5 0.]
+θ1 = EmpiricalRisks.view(θ, :, 2)
+θ2 = similar(θ1)
+@test value(reg, θ1) == 0. 
+@test prox!(reg, θ2, θ1, 1.0) == [0.5, 0.]
+
+θ1 = EmpiricalRisks.view(θ, 1, :)
+θ2 = similar(θ1)
+@test value(reg, θ1) == 0.
+@test prox!(reg, θ2, θ1, 1.0) == [0. 0.5]
+
+
+
+reg = SimplexReg(1.0)
+
+θ = [0.1, 0.9]
+@test value(reg, θ) == 0.
+@test_throws ErrorException value_and_addgrad!(reg, 0., similar(θ), 1., θ) 
+@test prox!(reg, θ, θ, 1.0) == [0.1, 0.9]
+
+θ = [0., 0.]
+@test value(reg, θ) == Inf
+@test prox!(reg, θ, θ, 1.0) == [0.5, 0.5]
+
+θ = [0., -1., 4., -0.1]
+@test value(reg, θ) == Inf  
+@test prox!(reg, θ, θ, 1.0) == [0., 0., 1., 0.]
+
+θ = [0. 1. ; 1. 0]
+@test value(reg, θ) == Inf
+@test prox!(reg, θ, θ, 1.0) == [0. 0.5 ; 0.5 0.]
+
+θ = [0. 0.5 ; 0.5 0.]
+θ1 = EmpiricalRisks.view(θ, :, 2)
+θ2 = similar(θ1)
+@test value(reg, θ1) == Inf
+@test prox!(reg, θ2, θ1, 1.0) == [0.75, 0.25]
+
+θ1 = EmpiricalRisks.view(θ, 1, :)
+θ2 = similar(θ1)
+@test value(reg, θ1) == Inf
+@test prox!(reg, θ2, θ1, 1.0) == [0.25 0.75]
+
+
+
+reg = L1BallReg(1.0)
+
+θ = [0.1, 0.9]
+@test value(reg, θ) == 0.
+@test_throws ErrorException value_and_addgrad!(reg, 0., similar(θ), 1., θ) 
+@test prox!(reg, θ, θ, 1.0) == [0.1, 0.9]
+
+θ = [0.2, -0.5]
+@test value(reg, θ) == 0. 
+@test prox!(reg, θ, θ, 1.0) == [0.2, -0.5]
+
+θ = [0., -1., 4., -0.1]
+@test value(reg, θ) == Inf
+@test prox!(reg, θ, θ, 1.0) == [0., 0., 1., 0.]
+
+θ = [0. 1. ; -1. 0]
+@test value(reg, θ) == Inf  
+@test prox!(reg, θ, θ, 1.0) == [0. 0.5 ; -0.5 0]
+
+θ = [0. 0.5 ; 0.5 0.]
+θ1 = EmpiricalRisks.view(θ, :, 2)
+θ2 = similar(θ1)
+@test value(reg, θ1) == 0. 
+@test prox!(reg, θ2, θ1, 1.0) == [0.5, 0.]
+
+θ1 = EmpiricalRisks.view(θ, 1, :)
+θ2 = similar(θ1)
+@test value(reg, θ1) == 0.
+@test prox!(reg, θ2, θ1, 1.0) == [0. 0.5]


### PR DESCRIPTION
Hi @lindahua 

In reference to issue #2 
This PR proposes 3 new regularizers : `NonNegReg()` for non negative parameter,  `SimplexReg(c)` for the simplex constraint and `L1BallReg(c)` for the L1 Ball constraint.
All are "projection" regularizers in that they force the parameter to belong to the validity domain. This entails that : 
- They have no defined gradient (can only be used in proximal gradient kind of optimizations)
- Their `value` method returns either 0 (valid) or Inf (not valid)
- Their `prox!` method ignores the `Lambda` parameter as the proximal step projects the parameter to the closest valid point.

`prox!` for `SimplexReg` and  `L1BallReg` implement a fast algorithm that that does not require the sorting of the parameter values and runs in O(n) steps. It does however require an allocation of a vector of similar size as the parameter. Compared to other regularizers the run time is only a small multiple even for large parameter sizes.

I have also added updated tests (but left docs and README untouched). 

As for propagating to optimization functions the fact that there is no gradient, it simply throws an error message in the present form, no traits or subtypes have been used.
