### PR TITLE
use _checkdims macro

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -20,7 +20,7 @@ function axpby!{T<:BlasReal}(a::T, x::StridedVector{T}, b::T, y::StridedVector{T
         axpy!(a, x, y)
     else
         n = length(x)
-        length(y) == n || throw(DimensionMismatch())
+        @_checkdims length(y) == n
         @inbounds for i = 1:n
             y[i] = a * x[i] + b * y[i]
         end


### PR DESCRIPTION
just a very very minor consistency thing I saw while going through the code. Since the macro is defined, might as well use it for beauty reasons :-). I'm guessing the macro was defined after that piece of code was written.
