### PR TITLE
Add squared hinge loss for L2-SVM

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This package provides basic components for implementing regularized empirical ri
   - [x] quantile loss
   - [x] huber loss
   - [x] hinge loss
+  - [x] squared hinge loss
   - [x] smoothed hinge loss
   - [x] logistic loss
   - [x] sum squared loss (for multivariate prediction)

--- a/src/EmpiricalRisks.jl
+++ b/src/EmpiricalRisks.jl
@@ -23,6 +23,7 @@ export
     QuantileLoss,
     HuberLoss,
     HingeLoss,
+    SqrHingeLoss,
     SmoothedHingeLoss,
     LogisticLoss,
     SumLoss,

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -125,12 +125,16 @@ end
 immutable SqrHingeLoss <: UnivariateLoss
 end
 
-value{T<:BlasReal}(::SqrHingeLoss, p::T, y::T) = nonneg(one(T) - y * p).^2
-deriv{T<:BlasReal}(::SqrHingeLoss, p::T, y::T) = y * p < one(T) ? 2(p-y) : zero(T)
+function value{T<:BlasReal}(::SqrHingeLoss, p::T, y::T)
+    yp = y * p
+    yp >= one(T) ? zero(T) : half(abs2(nonneg(one(T) - yp)))
+end
+
+deriv{T<:BlasReal}(::SqrHingeLoss, p::T, y::T) = y * p < one(T) ? (p - y) : zero(T)
 
 function value_and_deriv{T<:BlasReal}(::SqrHingeLoss, p::T, y::T)
     yp = y * p
-    yp >= one(T) ? (zero(T), zero(T)) : ((one(T) - yp).^2, 2(p-y))
+    yp >= one(T) ? (zero(T), zero(T)) : (half(abs2(one(T) - yp)), (p - y))
 end
 
 

--- a/src/loss.jl
+++ b/src/loss.jl
@@ -102,7 +102,7 @@ end
 
 
 
-## Hinge loss (for SVM)
+## Hinge loss (for L1-SVM)
 #
 #   loss(p, y) := max(1 - y * p, 0)
 #
@@ -115,6 +115,22 @@ deriv{T<:BlasReal}(::HingeLoss, p::T, y::T) = y * p < one(T) ? -y : zero(T)
 function value_and_deriv{T<:BlasReal}(::HingeLoss, p::T, y::T)
     yp = y * p
     yp >= one(T) ? (zero(T), zero(T)) : (one(T) - yp, -y)
+end
+
+
+## Squared Hinge loss (for L2-SVM)
+#
+#   loss(p, y) := max(1 - y * p, 0)^2
+#
+immutable SqrHingeLoss <: UnivariateLoss
+end
+
+value{T<:BlasReal}(::SqrHingeLoss, p::T, y::T) = nonneg(one(T) - y * p).^2
+deriv{T<:BlasReal}(::SqrHingeLoss, p::T, y::T) = y * p < one(T) ? 2(p-y) : zero(T)
+
+function value_and_deriv{T<:BlasReal}(::SqrHingeLoss, p::T, y::T)
+    yp = y * p
+    yp >= one(T) ? (zero(T), zero(T)) : ((one(T) - yp).^2, 2(p-y))
 end
 
 

--- a/test/uniloss.jl
+++ b/test/uniloss.jl
@@ -77,7 +77,7 @@ verify_uniloss(HingeLoss(), _hingef, -2.0:0.5:2.0, [-1.0, 1.0])
 
 # SquaredHingeLoss
 
-_sqrhingef(u::Dual, y) = y * real(u) < 1.0 ? (1.0 - y * u).^2 : dual(0.0, 0.0)
+_sqrhingef(u::Dual, y) = y * real(u) < 1.0 ? .5(1.0 - y * u).^2 : dual(0.0, 0.0)
 verify_uniloss(SqrHingeLoss(), _sqrhingef, -2.0:0.5:2.0, [-1.0, 1.0])
 
 

--- a/test/uniloss.jl
+++ b/test/uniloss.jl
@@ -75,6 +75,12 @@ _hingef(u::Dual, y) = y * real(u) < 1.0 ? 1.0 - y * u : dual(0.0, 0.0)
 verify_uniloss(HingeLoss(), _hingef, -2.0:0.5:2.0, [-1.0, 1.0])
 
 
+# SquaredHingeLoss
+
+_sqrhingef(u::Dual, y) = y * real(u) < 1.0 ? (1.0 - y * u).^2 : dual(0.0, 0.0)
+verify_uniloss(SqrHingeLoss(), _sqrhingef, -2.0:0.5:2.0, [-1.0, 1.0])
+
+
 # SmoothedHingeLoss
 
 function _sm_hingef(h::Float64, u::Dual, y)


### PR DESCRIPTION
As announced [here](https://github.com/Evizero/KSVM.jl/issues/1). I would need this Loss to make sure that the standard solver and the special SVM solver solve the same thing.

~~One thing I still have to address is a convenient way to specify C (1/(lambda*n)) in the regularizer definition. Don't know if I should make that a different PR~~ Can't be done cleanly for now. So I'll leave the Regularizer alone. Was just a convenience thing anyway
